### PR TITLE
fix password valid logic and ddGet offset bug

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -9,6 +9,9 @@ module.exports = {
     organization: 'Example',
     // Default password for ldap user
     userPassword: 'userPass',
+    // Cronjob for sync from dingtalk
+    cronJob: '0 0 * * *',
+    timeZone: 'Asia/Shanghai',
     // Admins who can search or modify directory
     admins: [
       {

--- a/config.example.js
+++ b/config.example.js
@@ -7,6 +7,8 @@ module.exports = {
     // Users base DN will be ou=People,o=Example,dc=example,dc=com
     rootDN: 'dc=example,dc=com',
     organization: 'Example',
+    // Default password for ldap user
+    userPassword: 'userPass',
     // Admins who can search or modify directory
     admins: [
       {

--- a/lib/db/db.js
+++ b/lib/db/db.js
@@ -16,9 +16,10 @@ async function getDBRecordForUserId(uid) {
     return record;
   }
 
+  // if can not find record from database, return null
   return {
     userid: uid,
-    password: '123456',
+    password: null,
   };
 }
 

--- a/lib/providers/dingtalk.js
+++ b/lib/providers/dingtalk.js
@@ -189,6 +189,7 @@ async function fetchDepartmentUsers(department) {
     });
     userlist.push(...users.userlist);
     hasMore = users.hasMore;
+    offset = offset + users.userlist.length;
   }
 
   userlist.forEach(u => {

--- a/lib/providers/dingtalk.js
+++ b/lib/providers/dingtalk.js
@@ -39,6 +39,16 @@ function parseName(name) {
     return { givenName, sn };
 }
 
+function parseMail(mail) {
+    let sAMAccountName=mail;
+    if (mail && mail.indexOf('@') > 0) {
+      const parts = mail.split('@');
+      sAMAccountName = parts[0];
+    }
+
+    return sAMAccountName;
+}
+
 async function ddGet(path, params) {
   const apiUrl = path.substr(0, 8) === 'https://' ? path : api(path);
   const ret = await axios(apiUrl, { params }).catch(e => {
@@ -260,6 +270,7 @@ async function reloadFromDingtalkServer() {
     const dn = `mail=${mail},${u.firstDepartment.dn}`;
 
     const { givenName, sn } = parseName(u.name);
+    const sAMAccountName = parseMail(mail);
 
     // 映射到 iNetOrgPerson
     const personEntry = makePersonEntry(dn, {
@@ -270,6 +281,7 @@ async function reloadFromDingtalkServer() {
       givenName,
       sn,
       mail,
+      sAMAccountName,
       avatarurl: u.avatar,
     });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -242,9 +242,9 @@ function runVirtualLDAPServer() {
   });
 
   // reload data from server every hour
-  new CronJob('0 0 * * * *', () => {
+  new CronJob(ldapConfig.cronJob || '0 0 * * * *', () => {
     reloadEntriesFromProvider();
-  }, null, true, 'Asia/Shanghai').start();
+  }, null, true, ldapConfig.timeZone || 'Asia/Shanghai').start();
 }
 
 module.exports = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -197,7 +197,6 @@ server.modify(getOrganizationBaseDN(), authorize, async (req, res, next) => {
 server.bind(getRootDN(), async (req, res, next) => {
   const reqDN = parseDN(req.dn.toString().toLowerCase());
   log.debug('bind req', reqDN.toString())
-  // console.log('bind PW: ' + req.credentials);
   if (parseDN(getRootDN().toLowerCase()).equals(reqDN.parent())) {
     // admins
     const username = reqDN.rdns[0].attrs.cn.value;
@@ -212,7 +211,14 @@ server.bind(getRootDN(), async (req, res, next) => {
     // users
     const matchedUser = getPersonMatchedDN(reqDN);
     if (matchedUser) {
+      log.debug('Found user:', matchedUser)
       const record = await getDBRecordForUserId(matchedUser.attributes.uid);
+      if(! record['password']) {
+          log.info('Password in database is null, use ldap value, user is', reqDN)
+          record['password'] = matchedUser['attributes']['userPassword']
+      }
+      log.debug('Ldap compare value is', record)
+      log.debug('Request credentials is', req.credentials)
       if (record && validateUserPassword(record.password, req.credentials)) {
         res.end();
         return next();
@@ -221,7 +227,7 @@ server.bind(getRootDN(), async (req, res, next) => {
         return next(new ldap.InvalidCredentialsError());
       }
     } else {
-      log.debug('user not found');
+      log.warning('user is not found:', reqDN);
       return next(new ldap.InvalidCredentialsError());
     }
   }

--- a/lib/utilities/ldap.js
+++ b/lib/utilities/ldap.js
@@ -74,7 +74,8 @@ function makePersonEntry(dn, attrs) {
     dn: generatedDN,
     attributes: Object.assign({
       objectclass: ['inetOrgPerson', 'organizationalPerson', 'person', 'top'],
-      userPassword: '********',
+      // userPassword: '********',
+      userPassword: ldapConfig.userPassword || 'userPass',
       // otpSecret: 'abcd',
       memberOf: [],
       entryDN: dn,


### PR DESCRIPTION
主要修改内容：
1. 修复默认 LDAP 用户密码的验证逻辑
2. 在 config.js 中增加 userPassword 配置允许自定义
3. 增加两个配置 cronJob 和 timeZone 来同步 dingtalk 数据
4. 增加用户登录名称属性 sAMAccountName，许多系统需要用到英文的用户名
5. 使用邮箱前缀作为用户名，因为在一个组织下，邮箱名称不会重复
6. 修正部门超过 100 人的 offset 未修改问题

本次修复借鉴 <https://github.com/xiaoquqi/virtual-ldap>，感谢 @xiaoquqi
通过实际测试，可正常使用